### PR TITLE
Add send-xbtc script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "generate-keys": "yarn r scripts/generate-keys.ts",
     "check-config": "yarn r scripts/check-config.ts",
     "register-supplier": "yarn r scripts/register-supplier.ts",
+    "send-xbtc": "yarn r scripts/send-xbtc.ts",
     "eslint:ci": "eslint 'src/**/*.ts' 'scripts/**/*.ts'",
     "lint:prettier": "prettier --check \"{src,scripts}/**/*.{ts,tsx}\"",
     "lint": "yarn eslint:ci && yarn lint:prettier",

--- a/scripts/send-xbtc.ts
+++ b/scripts/send-xbtc.ts
@@ -1,0 +1,198 @@
+import 'dotenv/config';
+import 'cross-fetch/polyfill';
+import { prompt } from 'inquirer';
+import {
+  validateStacksAddress,
+  privateKeyToStxAddress,
+  StacksNetworkVersion,
+} from 'micro-stacks/crypto';
+import { noneCV, principalCV, uintCV } from 'micro-stacks/clarity';
+import {
+  AnchorMode,
+  broadcastTransaction,
+  createAssetInfo,
+  FungibleConditionCode,
+  makeContractCall,
+  makeStandardFungiblePostCondition,
+  PostConditionMode,
+} from 'micro-stacks/transactions';
+import { StacksTestnet } from 'micro-stacks/network';
+
+// type definitions
+
+interface Answers {
+  recipient: string;
+  amount: number;
+  fee: number;
+}
+
+interface Balances {
+  ustx: number;
+  xbtc: number;
+}
+
+// helpers
+
+const toMacro = (value: number, decimals: number) => (value / 10 ** decimals).toFixed(decimals);
+const printDivider = () => console.log(`------------------------------`);
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const networkVersion = StacksNetworkVersion.testnetP2PKH;
+const stacksNetwork = new StacksTestnet({
+  coreApiUrl: 'https://stacks-node-api.testnet.stacks.co',
+});
+
+// fetchers
+
+async function fetchJson(url: string): Promise<any> {
+  const response = await fetch(url);
+  if (response.status === 200) {
+    const json = await response.json();
+    return json;
+  }
+  console.error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  process.exit(1);
+}
+
+async function fetchBalances(principal: string): Promise<Balances> {
+  const url = `https://stacks-node-api.testnet.stacks.co/extended/v1/address/${principal}/balances`;
+  const result = await fetchJson(url);
+  return {
+    ustx: result.stx.balance,
+    xbtc: result.fungible_tokens[
+      'ST2ZTY9KK9H0FA0NVN3K8BGVN6R7GYVFG6BE7TAR1.Wrapped-Bitcoin::wrapped-bitcoin'
+    ]
+      ? result.fungible_tokens[
+          'ST2ZTY9KK9H0FA0NVN3K8BGVN6R7GYVFG6BE7TAR1.Wrapped-Bitcoin::wrapped-bitcoin'
+        ].balance
+      : 0,
+  };
+}
+
+async function fetchNonce(principal: string): Promise<number> {
+  const url = `https://stacks-node-api.testnet.stacks.co/extended/v1/address/${principal}/nonces`;
+  const result = await fetchJson(url);
+  return +result.possible_next_nonce;
+}
+
+// main thread
+
+async function run() {
+  printDivider();
+  console.log('ACCOUNT INFO');
+  printDivider();
+  if (!process.env.SUPPLIER_STX_KEY) {
+    console.error('SUPPLIER_STX_KEY not found in .env file.');
+    process.exit(1);
+  }
+  const address = privateKeyToStxAddress(process.env.SUPPLIER_STX_KEY, networkVersion);
+  console.log(`address:`);
+  console.log(`  ${address}`);
+  const balances = await fetchBalances(address);
+  console.log('balances:');
+  console.log(`  ${toMacro(balances.ustx, 6)} STX`);
+  console.log(`  ${toMacro(balances.xbtc, 8)} xBTC`);
+  printDivider();
+  console.log('CONFIGURATION');
+  printDivider();
+  const answers = await prompt<Answers>([
+    {
+      name: 'recipient',
+      type: 'input',
+      message: 'Recipient address:',
+    },
+    {
+      name: 'amount',
+      type: 'number',
+      message: 'Amount of micro-xBTC to send?',
+    },
+    {
+      name: 'fee',
+      type: 'number',
+      message: 'Amount of uSTX for fee?',
+    },
+  ]);
+  if (!validateStacksAddress(answers.recipient) || address === answers.recipient) {
+    console.error('Invalid recipient address.');
+    process.exit(1);
+  }
+  if (isNaN(answers.amount) || balances.xbtc < answers.amount) {
+    console.error('Insufficient xBTC balance for transfer.');
+    process.exit(1);
+  }
+  if (isNaN(answers.fee) || balances.ustx < answers.fee) {
+    console.error('Insufficient uSTX balance for fee.');
+    process.exit(1);
+  }
+  printDivider();
+  console.log('BUILD TRANSACTION');
+  printDivider();
+  const nonce = await fetchNonce(address);
+  console.log(`nonce: ${nonce}`);
+  console.log(`from: ${address}`);
+  console.log(`to: ${answers.recipient}`);
+  console.log(`amount: ${toMacro(answers.amount, 8)} xBTC`);
+  console.log(`fee: ${toMacro(answers.fee, 6)} STX`);
+  const { confirm } = await prompt<{ confirm: boolean }>([
+    {
+      name: 'confirm',
+      type: 'confirm',
+      message: 'Confirm details above?',
+    },
+  ]);
+  if (!confirm) {
+    console.error('Details not confirmed.');
+    process.exit(1);
+  }
+  const txOptions = {
+    contractAddress: 'ST2ZTY9KK9H0FA0NVN3K8BGVN6R7GYVFG6BE7TAR1',
+    contractName: 'Wrapped-Bitcoin',
+    functionName: 'transfer',
+    functionArgs: [
+      uintCV(answers.amount),
+      principalCV(address),
+      principalCV(answers.recipient),
+      noneCV(),
+    ],
+    senderKey: process.env.SUPPLIER_STX_KEY,
+    fee: answers.fee,
+    nonce: nonce,
+    postConditionMode: PostConditionMode.Deny,
+    postConditions: [
+      makeStandardFungiblePostCondition(
+        address,
+        FungibleConditionCode.Equal,
+        answers.amount,
+        createAssetInfo(
+          'ST2ZTY9KK9H0FA0NVN3K8BGVN6R7GYVFG6BE7TAR1',
+          'Wrapped-Bitcoin',
+          'wrapped-bitcoin'
+        )
+      ),
+    ],
+    network: stacksNetwork,
+    anchorMode: AnchorMode.Any,
+  };
+  printDivider();
+  console.log('SEND TRANSACTION');
+  printDivider();
+  console.log('pausing for 10sec');
+  await sleep(10000);
+  try {
+    const tx = await makeContractCall(txOptions);
+    await broadcastTransaction(tx, stacksNetwork);
+    console.log(`TXID: 0x${tx.txid()}`);
+    console.log(`LINK: https://explorer.stacks.co/txid/0x${tx.txid()}?chain=testnet`);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+  printDivider();
+  console.log('Transfer successfully submitted!');
+}
+
+run()
+  .catch(console.error)
+  .finally(() => {
+    process.exit();
+  });

--- a/scripts/send-xbtc.ts
+++ b/scripts/send-xbtc.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import 'cross-fetch/polyfill';
 import { prompt } from 'inquirer';
 import {


### PR DESCRIPTION
## send-xbtc.ts

This PR adds a script to send xBTC using the private key stored in the environment file.

To test it, run `yarn send-xbtc`

It's a bit opinionated in the formatting, but I tried to follow the conventions I saw in other scripts. I am definitely open to suggestions/revisions and figured this would be a good starting point.

I know a few of the fetchers could implement micro-stacks functions, but I wasn't sure of the best way to do that and went with querying the node directly instead.

There are a few basic checks that result in an error + exit if something goes wrong, including:

- SUPPLIER_STX_KEY not found in .env file.
- Invalid recipient address.
- Insufficient xBTC balance for transfer.
- Insufficient uSTX balance for fee.
- Details not confirmed.

As well as a generic catch on making the contract call and broadcasting:

https://github.com/whoabuddy/magicstx-supplier-server/blob/db7d92d210465a4402268d21ba641b7218fb676a/scripts/send-xbtc.ts#L180-L188

And a generic failure if a fetch doesn't receive a `200` response status:

https://github.com/whoabuddy/magicstx-supplier-server/blob/db7d92d210465a4402268d21ba641b7218fb676a/scripts/send-xbtc.ts#L46-L54

## screenshot

![Screenshot from 2022-07-27 09-34-54](https://user-images.githubusercontent.com/9038904/181302799-04bf636b-0f9f-4ace-86da-530987ac9be5.png)

[Transaction from image on testnet](https://explorer.stacks.co/txid/0xe27a6242df316e28ac29f3ec01a56a6040fe159356093ead34dfe987365ad93a?chain=testnet)

Open to feedback!